### PR TITLE
New EDCTs typed as hh:mm should always be in the future

### DIFF
--- a/src/components/EDCTDataGrid.tsx
+++ b/src/components/EDCTDataGrid.tsx
@@ -132,6 +132,12 @@ const EDCTDataGrid = ({
         newEDCTDateTime = DateTime.fromFormat(newEDCT.shortEDCT, "HH:mm", {
           zone: "UTC",
         });
+
+        // If the new time wound up being in the past then it really should be tomorrow.
+        // Fix it.
+        if (newEDCTDateTime < DateTime.utc()) {
+          newEDCTDateTime = newEDCTDateTime.plus({ days: 1 });
+        }
       } else {
         setSnackbar({
           children: `Unable to updated EDCT: ${newEDCT.shortEDCT} is not a valid format.`,


### PR DESCRIPTION
Fixes #64